### PR TITLE
Update requirements.txt to include missing python-docx dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ Pillow==11.0.0
 opencv-python==4.10.0.84
 scikit-image==0.24.0
 PyPDF2==3.0.1
+python-docx==1.1.2


### PR DESCRIPTION
Added missing dependency python-docx

The Script wouldn't run on my System after installing requirements.txt because the Module python-docx is missing.
```
python prod.py
Traceback (most recent call last):
  File "/home/user/Downloads/WaterMarkRemovalTool/prod.py", line 6, in <module>
    from removerWord import remove_watermark_from_word
  File "/home/user/Downloads/WaterMarkRemovalTool/removerWord.py", line 1, in <module>
    from docx import Document
ModuleNotFoundError: No module named 'docx'
```


Installing python-docx fixes this, so I propose to add this to the requirements.txt

